### PR TITLE
Introduce `ignorePattern` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Configuration (TypeScript type).
 
 - `lowerCaseWords` (`string[]`, optional, example: `['die', 'der', 'und']`)
   — extends the default list of lowercase words.
+- `ignorePattern` (`string` || `string[]`, optional, example: `'package-[a-z]+'` or `['package-[a-z]+', 'node-[0-9]+']`)
+  — an array of or string regular expression pattern to ignore things that match the pattern.
 
 ## Examples
 

--- a/index.js
+++ b/index.js
@@ -28,26 +28,41 @@ export function fixTitle(title, options) {
     return word
   })
 
-  // Putting correct title in the cache for prevent handling the same titles in other docs.
+  // Putting correct title in the cache to prevent handling the same titles in other docs.
   cache[correctTitle] = correctTitle
 
   return correctTitle
 }
 
 function headingCapitalization(tree, file, options = {}) {
-  visit(tree, 'heading', node => {
-    const title = node.children.map(child => child.value).join('')
+  const { ignorePattern, lowerCaseWords = [] } = options
+  let ignorePatterns = []
 
-    // If the title is found among the correct titles - no calculations are performed.
-    if (cache[title]) {
+  // Process ignorePattern to create an array of regular expressions
+  if (Array.isArray(ignorePattern)) {
+    ignorePatterns = ignorePattern.map(pattern => new RegExp(pattern, 'g'))
+  } else if (ignorePattern) {
+    ignorePatterns = [new RegExp(ignorePattern, 'g')]
+  }
+
+  visit(tree, 'heading', node => {
+    let processedTitle = node.children.reduce((acc, child) => acc + (child.type === 'inlineCode' ? `\`${child.value}\`` : child.value), '')
+
+    // Create a processed version of the title by removing ignored patterns
+    for (const regex of ignorePatterns) {
+      processedTitle = processedTitle.replace(regex, '')
+    }
+
+    // If the processed title is found among the correct titles, skip further processing
+    if (cache[processedTitle]) {
       return
     }
 
-    const correctTitle = fixTitle(title, options)
+    const correctTitle = fixTitle(processedTitle, options)
 
-    if (correctTitle !== title) {
+    if (correctTitle !== processedTitle) {
       file.message(
-        `Heading capitalization error. Expected: '${correctTitle}' found: '${title}'`,
+        `Heading capitalization error. Expected: '${correctTitle}' found: '${processedTitle}'`,
         node
       )
     }

--- a/test/test.js
+++ b/test/test.js
@@ -49,3 +49,45 @@ test('custom list of lowercase words', async () => {
 
   assert.strictEqual(result1.messages.length, 0)
 })
+
+test('custom ignored pattern', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['`[^`]+`']
+    })
+    .process('# How to Use Our `awesome` Library')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern on multiple words', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['`[^`]+`']
+    })
+    .process('# How to Use Our `awesome` Library with `magical-stuff`!')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern with a string', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: 'package-[a-z]+'
+    })
+    .process('# Read About Our package-manager Barn!')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom multiple ignored patterns', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['package-[a-z]+', '`[^`]+`']
+    })
+    .process('# Read About Our package-manager Barn! Also Check Our `awesome` Library!')
+
+  console.log(result1.messages);
+
+  assert.strictEqual(result1.messages.length, 0)
+})


### PR DESCRIPTION
This option allows users to ignore patterns that are not linted using regular expressions.

Another improvement is to keep backticks around inline code nodes.