### PR TITLE
Introduce `ignorePattern` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ Configuration (TypeScript type).
 - `exclude` (`string[]`, optional, example: `['remark-lint', 'remark']`)
   — exclude the words from capitalization.
 
+- `ignorePattern` (`string` || `string[]`, optional, example: `'package-[a-z]+'` or `['package-[a-z]+', 'node-[0-9]+']`)
+  — an array of or string regular expression pattern to ignore things that match the pattern.
+
 ## Examples
 
 When this rule is turned on, the following `valid.md` is ok:

--- a/package.json
+++ b/package.json
@@ -66,5 +66,6 @@
   "dependencies": {
     "unified-lint-rule": "^2.1.2",
     "unist-util-visit": "^5.0.0"
-  }
+  },
+  "packageManager": "pnpm@9.15.0+sha512.76e2379760a4328ec4415815bcd6628dee727af3779aaa4c914e3944156c4299921a89f976381ee107d41f12cfa4b66681ca9c718f0668fa0831ed4c6d8ba56c"
 }

--- a/test/test.js
+++ b/test/test.js
@@ -53,9 +53,51 @@ test('custom list of lowercase words', async () => {
 test('custom list of excluded words', async () => {
   const result1 = await remark()
     .use(remarkLintHeadingCapitalization, {
-      exclude: ['remark-lint', 'remark']
+      exclude: ['`remark-lint`', '`remark`']
     })
     .process('# Contributing to `remark-lint` and `remark`')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['`[^`]+`']
+    })
+    .process('# How to Use Our `awesome` Library')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern on multiple words', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['`[^`]+`']
+    })
+    .process('# How to Use Our `awesome` Library with `magical-stuff`!')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom ignored pattern with a string', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: 'package-[a-z]+'
+    })
+    .process('# Read About Our package-manager Barn!')
+
+  assert.strictEqual(result1.messages.length, 0)
+})
+
+test('custom multiple ignored patterns', async () => {
+  const result1 = await remark()
+    .use(remarkLintHeadingCapitalization, {
+      ignorePattern: ['package-[a-z]+', '`[^`]+`']
+    })
+    .process('# Read About Our package-manager Barn! Also Check Our `awesome` Library!')
+
+  console.log(result1.messages);
 
   assert.strictEqual(result1.messages.length, 0)
 })


### PR DESCRIPTION
This option allows users to ignore patterns that are not linted using regular expressions.

Another improvement is to keep backticks around inline code nodes.